### PR TITLE
added faye endpoint support

### DIFF
--- a/faye.go
+++ b/faye.go
@@ -1,0 +1,70 @@
+package gitter
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mrexodia/wray"
+)
+
+type Faye struct {
+	endpoint string
+	Event    chan Event
+	client   *wray.FayeClient
+	gitter   *Gitter
+}
+
+func (gitter *Gitter) Faye(roomID string) *Faye {
+	wray.RegisterTransports([]wray.Transport{
+		&wray.HttpTransport{
+			SendHook: func(data map[string]interface{}) {
+				if channel, ok := data["channel"]; ok && channel == "/meta/handshake" {
+					data["ext"] = map[string]interface{}{"token": gitter.config.token}
+				}
+			},
+		},
+	})
+	return &Faye{
+		endpoint: "/api/v1/rooms/" + roomID + "/chatMessages",
+		Event:    make(chan Event),
+		client:   wray.NewFayeClient(gitterFayeAPI),
+		gitter:   gitter,
+	}
+}
+
+func (faye *Faye) Listen() {
+	defer faye.destroy()
+
+	faye.client.Subscribe(faye.endpoint, false, func(message wray.Message) {
+		dataBytes, err := json.Marshal(message.Data["model"])
+		if err != nil {
+			fmt.Printf("JSON Marshal error: %v\n", err)
+			return
+		}
+		var gitterMessage Message
+		err = json.Unmarshal(dataBytes, &gitterMessage)
+		if err != nil {
+			fmt.Printf("JSON Unmarshal error: %v\n", err)
+			return
+		}
+		faye.Event <- Event{
+			Data: &MessageReceived{
+				Message: gitterMessage,
+			},
+		}
+	})
+
+	//TODO: this might be needed in the future
+	/*go func() {
+		for {
+			faye.client.Publish("/api/v1/ping2", map[string]interface{}{"reason": "ping"})
+			time.Sleep(60 * time.Second)
+		}
+	}()*/
+
+	faye.client.Listen()
+}
+
+func (faye *Faye) destroy() {
+	close(faye.Event)
+}

--- a/gitter.go
+++ b/gitter.go
@@ -20,6 +20,7 @@ import (
 
 var gitterRESTAPI = "https://api.gitter.im/v1/"
 var gitterStreamAPI = "https://stream.gitter.im/v1/"
+var gitterFayeAPI = "https://ws.gitter.im/faye"
 
 type Gitter struct {
 	config struct {


### PR DESCRIPTION
still slightly experimental, however receiving room messages was tested and working fine (on the same interface as the Stream):

```
	faye := api.Faye(room.ID)
	go faye.Listen()

	for {
		event := <-faye.Event
		switch ev := event.Data.(type) {
		case *gitter.MessageReceived:
			if ev.Message.From.Username != user.Username {
				ircMsg := fmt.Sprintf("<%v> %v", ev.Message.From.Username, ev.Message.Text)
				fmt.Printf("[Gitter] %v\n", ircMsg)
			}
		case *gitter.GitterConnectionClosed: //this one is never called in Faye
			fmt.Printf("[Gitter] Connection closed...\n")
		}
	}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sromku/go-gitter/4)
<!-- Reviewable:end -->
